### PR TITLE
add cltorch support for neuralconvo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Here's a sample conversation after training for 10 epoch with only 5000 examples
 th train.lua --cuda --dataset 5000 --hiddenSize 1000
 ```
 
+for opencl, you can use the following command:
+
+```sh
+th train.lua --opencl --dataset 5000 --hiddenSize 1000
+```
+
 > **me:** Hi  
 > **bot:** Hey.
 > 
@@ -82,6 +88,13 @@ If you manage to run it on a larger network do let me know!
    luarocks install cutorch
    luarocks install cunn
    ```
+   
+   To train with opencl install the lastest Opencl torch lib:
+
+   ```sh
+   luarocks install cltorch
+   luarocks install clnn
+   ```
 
 3. Download the [Cornell Movie-Dialogs Corpus](http://www.mpi-sws.org/~cristian/Cornell_Movie-Dialogs_Corpus.html) and extract all the files into data/cornell_movie_dialogs.
 
@@ -96,6 +109,7 @@ Use the `--dataset NUMBER` option to control the size of the dataset. Training o
 The model will be saved to `data/model.t7` after each epoch if it has improved (error decreased).
 
 ## Testing
+**still have problem for cltorch**
 
 To load the model and have a conversation:
 

--- a/neuralconvo.lua
+++ b/neuralconvo.lua
@@ -1,6 +1,8 @@
 require 'torch'
 require 'nn'
 require 'rnn'
+require 'cltorch'
+require 'clnn'
 
 neuralconvo = {}
 

--- a/seq2seq.lua
+++ b/seq2seq.lua
@@ -41,6 +41,17 @@ function Seq2Seq:cuda()
   self.zeroTensor = self.zeroTensor:cuda()
 end
 
+function Seq2Seq:cl()
+  self.encoder:cl()
+  self.decoder:cl()
+
+  if self.criterion then
+    self.criterion:cl()
+  end
+
+  self.zeroTensor = self.zeroTensor:cl()
+end
+
 --[[ Forward coupling: Copy encoder cell and output to decoder LSTM ]]--
 function Seq2Seq:forwardConnect(inputSeqLen)
   self.decoderLSTM.userPrevOutput =

--- a/train.lua
+++ b/train.lua
@@ -13,7 +13,6 @@ cmd:option('--minLR', 0.00001, 'minimum learning rate')
 cmd:option('--saturateEpoch', 20, 'epoch at which linear decayed LR will reach minLR')
 cmd:option('--maxEpoch', 50, 'maximum number of epochs to run')
 cmd:option('--batchSize', 1000, 'number of examples to load at once')
---cmd:option('--opencl',0,'use OpenCL (instead of CUDA)')
 
 cmd:text()
 options = cmd:parse(arg)
@@ -77,6 +76,9 @@ for epoch = 1, options.maxEpoch do
       if options.cuda then
         input = input:cuda()
         target = target:cuda()
+      else 
+        input = input:cl()
+        target = target:cl()
       end
 
       local err = model:train(input, target)

--- a/train.lua
+++ b/train.lua
@@ -13,6 +13,7 @@ cmd:option('--minLR', 0.00001, 'minimum learning rate')
 cmd:option('--saturateEpoch', 20, 'epoch at which linear decayed LR will reach minLR')
 cmd:option('--maxEpoch', 50, 'maximum number of epochs to run')
 cmd:option('--batchSize', 1000, 'number of examples to load at once')
+--cmd:option('--opencl',0,'use OpenCL (instead of CUDA)')
 
 cmd:text()
 options = cmd:parse(arg)
@@ -50,7 +51,12 @@ if options.cuda then
   require 'cutorch'
   require 'cunn'
   model:cuda()
+else
+  require 'cltorch'
+  require 'clnn'
+  model:cl()
 end
+
 
 -- Run the experiment
 

--- a/train.lua
+++ b/train.lua
@@ -6,6 +6,7 @@ cmd:text('Options:')
 cmd:option('--dataset', 0, 'approximate size of dataset to use (0 = all)')
 cmd:option('--minWordFreq', 1, 'minimum frequency of words kept in vocab')
 cmd:option('--cuda', false, 'use CUDA')
+cmd:option('--opencl', false, 'use opencl')
 cmd:option('--hiddenSize', 300, 'number of hidden units in LSTM')
 cmd:option('--learningRate', 0.05, 'learning rate at t=0')
 cmd:option('--momentum', 0.9, 'momentum')
@@ -50,7 +51,7 @@ if options.cuda then
   require 'cutorch'
   require 'cunn'
   model:cuda()
-else
+elseif options.opencl then
   require 'cltorch'
   require 'clnn'
   model:cl()
@@ -76,7 +77,7 @@ for epoch = 1, options.maxEpoch do
       if options.cuda then
         input = input:cuda()
         target = target:cuda()
-      else 
+      elseif options.opencl then
         input = input:cl()
         target = target:cl()
       end


### PR DESCRIPTION
install cltorch clnn first and update all things to the lastest.

```
luarocks install torch
luarocks install nn
luarocks install nngraph
luarocks install cltorch
luarcoks install clnn
```
then in the project directory, use

```
th train.lua --dataset 1000 --hiddenSize 500 --opencl
```

to run the training process.

```
bash-3.2$ th train.lua --dataset 1000 --hiddenSize 500 --opencl
libthclnn_searchpath	/Users/zhuxiaohu/torch/install/lib/lua/5.1/libTHCLNN.so
-- Loading dataset
Loading vocabulary from data/vocab.t7 ...

Dataset stats:
  Vocabulary size: 2536
         Examples: 1569
Using Apple , OpenCL platform: Apple
Using OpenCL device: HD Graphics 4000
...

```

**still have problem on evaluation step.**