### PR TITLE
Improve results by using entire output sequence as decoder input

### DIFF
--- a/neuralconvo.lua
+++ b/neuralconvo.lua
@@ -1,8 +1,6 @@
 require 'torch'
 require 'nn'
 require 'rnn'
-require 'cltorch'
-require 'clnn'
 
 neuralconvo = {}
 

--- a/seq2seq.lua
+++ b/seq2seq.lua
@@ -109,18 +109,19 @@ function Seq2Seq:eval(input)
   local probabilities = {}
 
   -- Forward <go> and all of it's output recursively back to the decoder
-  local output = self.goToken
+  local output = {self.goToken}
   for i = 1, MAX_OUTPUT_SIZE do
-    local prediction = self.decoder:forward(torch.Tensor{output})[1]
+    local prediction = self.decoder:forward(torch.Tensor(output))[#output]
     -- prediction contains the probabilities for each word IDs.
     -- The index of the probability is the word ID.
-    local prob, wordIds = prediction:sort(1, true)
+    local prob, wordIds = prediction:topk(5, 1, true, true)
 
     -- First one is the most likely.
-    output = wordIds[1]
+    next_output = wordIds[1]
+    table.insert(output, next_output)
 
     -- Terminate on EOS token
-    if output == self.eosToken then
+    if next_output == self.eosToken then
       break
     end
 

--- a/seq2seq.lua
+++ b/seq2seq.lua
@@ -26,8 +26,6 @@ function Seq2Seq:buildModel()
 
   self.encoder:zeroGradParameters()
   self.decoder:zeroGradParameters()
-
-  self.zeroTensor = torch.Tensor(2):zero()
 end
 
 function Seq2Seq:cuda()
@@ -37,8 +35,6 @@ function Seq2Seq:cuda()
   if self.criterion then
     self.criterion:cuda()
   end
-
-  self.zeroTensor = self.zeroTensor:cuda()
 end
 
 function Seq2Seq:cl()
@@ -48,8 +44,6 @@ function Seq2Seq:cl()
   if self.criterion then
     self.criterion:cl()
   end
-
-  self.zeroTensor = self.zeroTensor:cl()
 end
 
 --[[ Forward coupling: Copy encoder cell and output to decoder LSTM ]]--
@@ -74,7 +68,7 @@ function Seq2Seq:train(input, target)
   local decoderTarget = target:sub(2, -1)
 
   -- Forward pass
-  self.encoder:forward(encoderInput)
+  local encoderOutput = self.encoder:forward(encoderInput)
   self:forwardConnect(encoderInput:size(1))
   local decoderOutput = self.decoder:forward(decoderInput)
   local Edecoder = self.criterion:forward(decoderOutput, decoderTarget)
@@ -87,7 +81,7 @@ function Seq2Seq:train(input, target)
   local gEdec = self.criterion:backward(decoderOutput, decoderTarget)
   self.decoder:backward(decoderInput, gEdec)
   self:backwardConnect()
-  self.encoder:backward(encoderInput, self.zeroTensor)
+  self.encoder:backward(encoderInput, encoderOutput:zero())
 
   self.encoder:updateGradParameters(self.momentum)
   self.decoder:updateGradParameters(self.momentum)


### PR DESCRIPTION
This greatly improves decoder output by changing `output` (input to the decoder) in `Seq2Seq:eval` from a single token to an array of tokens, appending each next token to this array. It seems that the LSTM does not retain this information by default (I hoped it would).

Before:

```
th> say "What time is it?"
>> It wasn've got nothing, if that've got nothing, if that've got nothing

th> say "Who are you?"
>> I was a lot.

th> say "What are you doing here?"
>> I live here the plants, let'you may need to see you may need to see you may

th> say "Why do you act like this?"
>> Because've got it got it got it got it got it got it got it got it got

th> say "I'm upset with your output."
>> It'have a werewolf'have a werewolf'have a werewolf'have a werewolf'have a

th> say "Please try to make more sense."
>> Oh god...

th> say "Got it."
>> Show us both got your show us both got your show us both got your show us both got your

th> say "Good stuff."
>> I.

th> say "What is the purpose of life?"
>> The!
```

After:

```
th> say "What time is it?"
>> It's time for you to stand where the hell i told you.

th> say "Who are you?"
>> I was...

th> say "What are you doing here?"
>> I thought you said there'd only be a dozen eggs.

th> say "Why do you act like this?"
>> Because it is the name of my father...

th> say "I'm upset with your output."
>> It's okay.

th> say "Please try to make more sense."
>> Oh, god...

th> say "Got it."
>> Show us where you are, chief.

th> say "Good stuff."
>> I've heard.

th> say "What is the purpose of life?"
>> The forward airlock.
```

Also fixes the "sizes do not match" problem from #17 and removes extraneous cltorch/clnn imports as seen in #23