### PR TITLE
fix for backwardConnect with latest LSTM from rnn

### DIFF
--- a/seq2seq.lua
+++ b/seq2seq.lua
@@ -65,11 +65,8 @@ function Seq2Seq:forwardConnect(inputSeqLen)
 end
 
 --[[ Backward coupling: Copy decoder gradients to encoder LSTM ]]--
-function Seq2Seq:backwardConnect()
-  self.encoderLSTM.userNextGradCell =
-    nn.rnn.recursiveCopy(self.encoderLSTM.userNextGradCell, self.decoderLSTM.userGradPrevCell)
-  self.encoderLSTM.gradPrevOutput =
-    nn.rnn.recursiveCopy(self.encoderLSTM.gradPrevOutput, self.decoderLSTM.userGradPrevOutput)
+function Seq2Seq:backwardConnect(inputSeqLen)
+  self.encoderLSTM:setGradHiddenState(inputSeqLen, self.decoderLSTM:getGradHiddenState(0))
 end
 
 local MAX_OUTPUT_SIZE = 20

--- a/train.lua
+++ b/train.lua
@@ -109,7 +109,7 @@ for epoch = 1, options.maxEpoch do
     -- Backward pass
     local dloss_doutput = model.criterion:backward(decoderOutput, decoderTargets)
     model.decoder:backward(decoderInputs, dloss_doutput)
-    model:backwardConnect()
+    model:backwardConnect(encoderInputs:size(1))
     model.encoder:backward(encoderInputs, encoderOutput:zero())
     
     gradParams:clamp(-options.gradientClipping, options.gradientClipping)


### PR DESCRIPTION
As you can see here:
https://github.com/Element-Research/rnn/commit/b756aeb763131637d4b158b566be7a6b223a3df3#diff-252114aaf00f46d74c886c6e9d12c187L40
Logic for backwardConnect has changed.